### PR TITLE
Fix shop buy buttons and audit

### DIFF
--- a/Peggame-cursor-debug-game-code-for-issues-cfbb/collision_system.lua
+++ b/Peggame-cursor-debug-game-code-for-issues-cfbb/collision_system.lua
@@ -40,6 +40,10 @@ local function applyPopperEffects(gameState, ball, peg, effectType)
         points = config.SCORING.CINCO_POPPER_POINTS
         effectText = "+" .. points .. " CINCO!"
         effectColor = {1, 0.8, 0.2}
+    elseif effectType == "yellow" and gameState.poppers and (gameState.poppers.bananaPopper or 0) > 0 then
+        points = config.SCORING.BANANA_POPPER_POINTS
+        effectText = "+" .. points .. " BANANA!"
+        effectColor = {1, 1, 0}
     end
     
     if points > 0 then
@@ -63,6 +67,7 @@ local function getPegColorType(peg)
     if r == 0.2 and g == 1 and b == 0.2 then return "green" end
     if r == 1 and g == 0.2 and b == 0.2 then return "red" end
     if r == 0 and g == 0.6 and b == 1 then return "blue" end
+    if r == 1 and g == 1 and b == 0 then return "yellow" end
     
     return nil
 end

--- a/Peggame-cursor-debug-game-code-for-issues-cfbb/collision_system.lua
+++ b/Peggame-cursor-debug-game-code-for-issues-cfbb/collision_system.lua
@@ -50,6 +50,14 @@ local function applyPopperEffects(gameState, ball, peg, effectType)
         gameState:ensureRoundState()
         gameState.currentRound.score = gameState.currentRound.score + points
         
+        -- Track popper activation for UI display
+        table.insert(gameState.popperActivations, {
+            type = effectType,
+            points = points,
+            timer = 2.0, -- Show for 2 seconds
+            color = effectColor
+        })
+        
         -- Show effect text for bounce effects (now only one)
         if effectType == "bounce" then
             visualEffects.addEffect(gameState, ball.x, ball.y - 20, effectText, effectColor)
@@ -283,8 +291,8 @@ function collisionSystem.checkBallPegCollision(gameState, ball, dt)
 
             -- Track pegs hit for Explosive Popper
             gameState.pegsHitThisRound = (gameState.pegsHitThisRound or 0) + 1
-            -- Explosive Popper: every 5th peg hit in a round
-            if gameState.poppers and (gameState.poppers.explosivePopper or 0) > 0 and gameState.pegsHitThisRound % 5 == 0 then
+            -- Explosive Popper: every 10th peg hit in a round
+            if gameState.poppers and (gameState.poppers.explosivePopper or 0) > 0 and gameState.pegsHitThisRound % 10 == 0 then
                 -- Red explosion effect: clear nearby pegs and add points
                 local explosionRadius = 220
                 local explosionScore = 0

--- a/Peggame-cursor-debug-game-code-for-issues-cfbb/collision_system.lua
+++ b/Peggame-cursor-debug-game-code-for-issues-cfbb/collision_system.lua
@@ -83,7 +83,7 @@ local function updateMultiplierMeter(gameState, ball)
         gameState.rainbowShockwave = config.RAINBOW_SHOCKWAVE_DURATION
         
         -- Create visual effects
-        local meterX = config.PLAY_X + config.PLAY_WIDTH + 50
+        local meterX = config.PLAY_X - 60 - 30  -- Match the new left-side meter position
         local meterY = config.PLAY_Y + config.PLAY_HEIGHT/2
         visualEffects.createRainbowShockwave(gameState, meterX, meterY)
         visualEffects.addEffect(gameState, ball.x, ball.y - 30, "SCORE DOUBLED!", config.COLORS.multiplier)

--- a/Peggame-cursor-debug-game-code-for-issues-cfbb/collision_system.lua
+++ b/Peggame-cursor-debug-game-code-for-issues-cfbb/collision_system.lua
@@ -168,14 +168,7 @@ function collisionSystem.checkBallPegCollision(gameState, ball, dt)
                 basePoints = math.max(1, math.floor(peg.points * 0.25))
                 peg.points = peg.points - basePoints
                 
-                -- Apply paprika bonus (25% increase to points gained)
-                local paprikaBonus = 0
-                for j, perk in ipairs(gameState.perks) do
-                    if perk == 2 then -- paprika perk
-                        paprikaBonus = paprikaBonus + (gameState.perkCounts[j] * 0.25)
-                    end
-                end
-                basePoints = math.floor(basePoints * (1 + paprikaBonus))
+
                 visualEffects.addEffect(gameState, peg.x + math.random(-20, 20), peg.y + math.random(-20, 20), "+" .. basePoints, config.COLORS.green)
             end
             
@@ -346,14 +339,7 @@ function collisionSystem.checkBallWallCollision(gameState, ball, dt)
     
     if wallHit then
         -- Score points with standardized values
-        local basePoints = (gameState.upgrades.wallPoints and config.SCORING.WALL_BASE_POINTS or 0) + config.SCORING.WALL_BASE_POINTS
-        local wallToWallBonus = 0
-        for _, perk in ipairs(gameState.perks) do
-            if perk == 1 then -- wall to wall perk
-                wallToWallBonus = wallToWallBonus + (gameState.wallToWallLevel * 5)
-            end
-        end
-        local totalPoints = basePoints + wallToWallBonus
+        local totalPoints = (gameState.upgrades.wallPoints and config.SCORING.WALL_BASE_POINTS or 0) + config.SCORING.WALL_BASE_POINTS
         local points = math.floor(totalPoints * gameState.multiplier)
         
         -- Apply multiplier popper effect to wall hits

--- a/Peggame-cursor-debug-game-code-for-issues-cfbb/collision_system.lua
+++ b/Peggame-cursor-debug-game-code-for-issues-cfbb/collision_system.lua
@@ -117,6 +117,9 @@ function collisionSystem.checkBallPegCollision(gameState, ball, dt)
     
     for i = #gameState.pegs, 1, -1 do
         local peg = gameState.pegs[i]
+        if not peg then
+            goto continue
+        end
         local dx = ball.x - peg.x
         local dy = ball.y - peg.y
         local dist = math.sqrt(dx*dx + dy*dy)
@@ -284,27 +287,38 @@ function collisionSystem.checkBallPegCollision(gameState, ball, dt)
             if gameState.poppers and (gameState.poppers.explosivePopper or 0) > 0 and gameState.pegsHitThisRound % 5 == 0 then
                 -- Red explosion effect: clear nearby pegs and add points
                 local explosionRadius = 220
+                local explosionScore = 0
                 for j = #gameState.pegs, 1, -1 do
                     local peg2 = gameState.pegs[j]
-                    local dx2 = peg.x - peg2.x
-                    local dy2 = peg.y - peg2.y
-                    if math.sqrt(dx2*dx2 + dy2*dy2) < explosionRadius and peg2 ~= peg then
-                        table.remove(gameState.pegs, j)
-                        table.remove(gameState.pegShapes, j)
+                    if peg2 and peg2 ~= peg then
+                        local dx2 = peg.x - peg2.x
+                        local dy2 = peg.y - peg2.y
+                        if math.sqrt(dx2*dx2 + dy2*dy2) < explosionRadius then
+                            -- Add the destroyed peg's points to explosion score
+                            explosionScore = explosionScore + (peg2.points or 5)
+                            table.remove(gameState.pegs, j)
+                            table.remove(gameState.pegShapes, j)
+                        end
                     end
                 end
-                gameState.currentRound.score = gameState.currentRound.score + config.SCORING.EXPLOSIVE_POPPER_POINTS
+                -- Add both explosion bonus and destroyed peg scores
+                local totalExplosionPoints = config.SCORING.EXPLOSIVE_POPPER_POINTS + explosionScore
+                gameState.currentRound.score = gameState.currentRound.score + totalExplosionPoints
                 -- Red explosion animation
                 if visualEffects and visualEffects.createExplosion then
                     visualEffects.createExplosion(gameState, peg.x, peg.y, {1,0,0})
                 end
                 visualEffects.addEffect(gameState, peg.x, peg.y, "EXPLOSION!", {1,0,0})
+                if explosionScore > 0 then
+                    visualEffects.addEffect(gameState, peg.x, peg.y - 40, "+" .. totalExplosionPoints, {1, 0.8, 0.2})
+                end
             end
             -- Combo Popper: bonus for 3+ pegs in a single bounce
             if gameState.poppers and (gameState.poppers.comboPopper or 0) > 0 and (ball.comboHitCount or 0) >= 3 then
                 applyPopperEffects(gameState, ball, peg, "combo")
             end
         end
+        ::continue::
     end
 end
 

--- a/Peggame-cursor-debug-game-code-for-issues-cfbb/config.lua
+++ b/Peggame-cursor-debug-game-code-for-issues-cfbb/config.lua
@@ -78,6 +78,7 @@ local config = {
         COMBO_POPPER_POINTS = 20,
         EXPLOSIVE_POPPER_POINTS = 50,
         CINCO_POPPER_POINTS = 250,
+        BANANA_POPPER_POINTS = 250,
         
         -- Bonus effects
         DOUBLE_HIT_BASE = 3,

--- a/Peggame-cursor-debug-game-code-for-issues-cfbb/game_state.lua
+++ b/Peggame-cursor-debug-game-code-for-issues-cfbb/game_state.lua
@@ -122,6 +122,7 @@ local gameState = {
     collisionCount = 0,
     scoreGlowTimer = 0,
     scoreScaleTimer = 0,
+    popperActivations = {}, -- Track recent popper activations for UI display
     wallHitTimer = nil,
     goldPegPositions = nil,
     bonusPegPositions = nil,
@@ -250,6 +251,7 @@ function gameState:reset()
     self.collisionCount = 0
     self.scoreGlowTimer = 0
     self.scoreScaleTimer = 0
+    self.popperActivations = {}
     self.wallHitTimer = nil
     self.goldPegPositions = nil
     self.bonusPegPositions = nil

--- a/Peggame-cursor-debug-game-code-for-issues-cfbb/game_state.lua
+++ b/Peggame-cursor-debug-game-code-for-issues-cfbb/game_state.lua
@@ -28,16 +28,11 @@ local gameState = {
         extraBall4 = false
     },
 
-    -- Perk system
+    -- Shop system
     maxBalls = 1,
     multiplierBoostLevel = 0,
-    paprikaLevel = 0,
-    perks = {0, 0, 0, 0, 0},
-    wallToWallLevel = 0,
-    perkCounts = {0, 0, 0, 0, 0},
     shopType = 1,
     shopItems = {},
-    shopPerks = {},
 
     -- Power-up system
     powerUps = {
@@ -100,14 +95,7 @@ local gameState = {
         {name="Multiplier Boost", desc="+5% multiplier gain per level", price=18, id="multiplierBoost"}
     },
 
-    allPerks = {
-        {name="Wall 2 Wall", desc="+2 points per wall hit", price=5, id="wallPoints"},
-        {name="Wall to Wall", desc="+5 points per wall hit", price=15, id="wallToWall"},
-        {name="Paprika", desc="+25% points from pegs", price=25, id="paprika"},
-        {name="Combo King", desc="Combo multiplier increases 25% faster", price=20, id="comboKing"},
-        {name="Explosion Expert", desc="Random explosions are 50% larger", price=25, id="explosionExpert"},
-        {name="Lucky Charm", desc="15% chance for power-ups to last longer", price=30, id="luckyCharm"}
-    },
+
 
     -- Visual effects
     effects = {},
@@ -210,13 +198,9 @@ function gameState:reset()
         extraBall4 = false
     }
     
-    -- Reset perk system
+    -- Reset shop system
     self.maxBalls = 1
     self.multiplierBoostLevel = 0
-    self.paprikaLevel = 0
-    self.perks = {0, 0, 0, 0, 0}
-    self.wallToWallLevel = 0
-    self.perkCounts = {0, 0, 0, 0, 0}
     
     -- Reset power-ups
     for _, powerUp in pairs(self.powerUps) do

--- a/Peggame-cursor-debug-game-code-for-issues-cfbb/game_state.lua
+++ b/Peggame-cursor-debug-game-code-for-issues-cfbb/game_state.lua
@@ -123,6 +123,7 @@ local gameState = {
     scoreGlowTimer = 0,
     scoreScaleTimer = 0,
     popperActivations = {}, -- Track recent popper activations for UI display
+    victoryTimer = 0, -- Timer for victory celebration before round summary
     wallHitTimer = nil,
     goldPegPositions = nil,
     bonusPegPositions = nil,
@@ -252,6 +253,7 @@ function gameState:reset()
     self.scoreGlowTimer = 0
     self.scoreScaleTimer = 0
     self.popperActivations = {}
+    self.victoryTimer = 0
     self.wallHitTimer = nil
     self.goldPegPositions = nil
     self.bonusPegPositions = nil

--- a/Peggame-cursor-debug-game-code-for-issues-cfbb/game_state.lua
+++ b/Peggame-cursor-debug-game-code-for-issues-cfbb/game_state.lua
@@ -121,6 +121,7 @@ local gameState = {
     time = 0,
     collisionCount = 0,
     scoreGlowTimer = 0,
+    scoreScaleTimer = 0,
     wallHitTimer = nil,
     goldPegPositions = nil,
     bonusPegPositions = nil,
@@ -248,6 +249,7 @@ function gameState:reset()
     self.rainbowShockwave = 0
     self.collisionCount = 0
     self.scoreGlowTimer = 0
+    self.scoreScaleTimer = 0
     self.wallHitTimer = nil
     self.goldPegPositions = nil
     self.bonusPegPositions = nil

--- a/Peggame-cursor-debug-game-code-for-issues-cfbb/main.lua
+++ b/Peggame-cursor-debug-game-code-for-issues-cfbb/main.lua
@@ -236,6 +236,15 @@ function love.update(dt)
         end
     end
     
+    -- Update popper activation timers
+    for i = #gameState.popperActivations, 1, -1 do
+        local activation = gameState.popperActivations[i]
+        activation.timer = activation.timer - dt
+        if activation.timer <= 0 then
+            table.remove(gameState.popperActivations, i)
+        end
+    end
+    
     -- Check for score increase and trigger effects
     if gameState.currentRound.score > (gameState.lastRoundScore or 0) then
         gameState.scoreGlowTimer = config.SCORE_GLOW_DURATION
@@ -345,6 +354,7 @@ function love.draw()
     
     if gameState.state == config.GAME_STATE.PLAYING then
         uiSystem.drawCandyRow(gameState)
+        uiSystem.drawPopperActivations(gameState)
     end
     
     -- Draw "Next Round" button during gameplay if score requirement met

--- a/Peggame-cursor-debug-game-code-for-issues-cfbb/main.lua
+++ b/Peggame-cursor-debug-game-code-for-issues-cfbb/main.lua
@@ -38,7 +38,6 @@ function love.load()
     uiSystem.initFonts(gameState)
     gameObjects.createPegs(gameState)
     shopSystem.rerollShopItems(gameState)
-    shopSystem.rerollShopPerks(gameState)
     
     -- Initialize wall hit timer
     gameState.wallHitTimer = nil
@@ -124,7 +123,6 @@ local function completeRound()
         local roundBonus = math.floor(gameState.currentRound.score / 400) + math.floor(gameState.lives / 2) + math.floor(gameState.round * 2)
         gameState.coins = gameState.coins + roundBonus
         shopSystem.rerollShopItems(gameState)
-        shopSystem.rerollShopPerks(gameState)
     end
 end
 
@@ -336,7 +334,6 @@ function love.draw()
         uiSystem.drawAimingSystem(gameState)
     end
     
-    -- Draw perk slots above play area (right side)
     if gameState.state == config.GAME_STATE.PLAYING then
         uiSystem.drawCandyRow(gameState)
     end
@@ -417,22 +414,7 @@ end
 
 -- Handle mouse presses
 function love.mousepressed(x, y, button)
-    if button == 2 and gameState.state == config.GAME_STATE.PLAYING then
-        -- Right click to remove perks
-        for i = 1, 5 do
-            local px = config.PLAY_X + config.PLAY_WIDTH - 60 - (i-1)*50
-            local py = 10
-            if x >= px and x <= px + 40 and y >= py and y <= py + 40 and gameState.perks[i] ~= 0 then
-                if gameState.perkCounts[i] > 1 then
-                    gameState.perkCounts[i] = gameState.perkCounts[i] - 1
-                else
-                    gameState.perks[i] = 0
-                    gameState.perkCounts[i] = 0
-                end
-                return
-            end
-        end
-    elseif button == 1 then
+    if button == 1 then
         -- Handle round summary clicks
         if roundSummary.active then
             local btnW, btnH = 220, 60
@@ -463,7 +445,6 @@ function love.mousepressed(x, y, button)
                 gameState.coins = gameState.coins + math.floor(gameState.currentRound.score / 500) + math.floor(gameState.lives / 2)
                 gameState.round = gameState.round + 1
                 shopSystem.rerollShopItems(gameState)
-                shopSystem.rerollShopPerks(gameState)
                 return
             end
             

--- a/Peggame-cursor-debug-game-code-for-issues-cfbb/main.lua
+++ b/Peggame-cursor-debug-game-code-for-issues-cfbb/main.lua
@@ -502,8 +502,8 @@ function love.mousepressed(x, y, button)
             local iconSize = 80
             local spacing = 90
             for i, item in ipairs(gameState.shopItems) do
-                local y = startY + (i-1)*spacing
-                local buyX, buyY, buyW, buyH = config.WIDTH/2 + iconSize/2 + 16, y + 20, 80, 40
+                local itemY = startY + (i-1)*spacing
+                local buyX, buyY, buyW, buyH = config.WIDTH/2 + iconSize/2 + 16, itemY + 20, 80, 40
                 local bought = gameState.poppers and (gameState.poppers[item.id] or 0) > 0
                 if not bought and x >= buyX and x <= buyX + buyW and y >= buyY and y <= buyY + buyH then
                     if gameState.coins >= item.price then
@@ -516,8 +516,8 @@ function love.mousepressed(x, y, button)
             local popperCount = #gameState.shopItems
             local candies = shopSystem.CANDIES
             for i, candy in ipairs(candies) do
-                local y = startY + popperCount * spacing + 60 + (i-1)*spacing
-                local buyX, buyY, buyW, buyH = config.WIDTH/2 + iconSize/2 + 16, y + 20, 80, 40
+                local candyY = startY + popperCount * spacing + 60 + (i-1)*spacing
+                local buyX, buyY, buyW, buyH = config.WIDTH/2 + iconSize/2 + 16, candyY + 20, 80, 40
                 local bought = gameState.candyBought and gameState.candyBought[candy.id]
                 if not bought and x >= buyX and x <= buyX + buyW and y >= buyY and y <= buyY + buyH then
                     if gameState.coins >= candy.price then

--- a/Peggame-cursor-debug-game-code-for-issues-cfbb/main.lua
+++ b/Peggame-cursor-debug-game-code-for-issues-cfbb/main.lua
@@ -94,8 +94,17 @@ local function checkRoundCompletion()
     -- Round completes when goal is reached OR all balls are used and none active
     local goalReached = gameState.currentRound.score >= gameState.goal
     local ballsFinished = gameState.currentRound.balls_remaining == 0 and gameState.currentRound.active_balls == 0
+    local allBallsStopped = gameState.currentRound.active_balls == 0
     
-    if (goalReached or ballsFinished) and not roundSummary.active then
+    if goalReached and allBallsStopped and gameState.victoryTimer == 0 and not roundSummary.active then
+        -- Start victory celebration - 2 second sparkle show
+        gameState.victoryTimer = 2.0
+        -- Create lots of rainbow sparkles for victory
+        local scoreX = config.PLAY_X + config.PLAY_WIDTH/2
+        local scoreY = config.PLAY_Y + config.PLAY_HEIGHT/2
+        visualEffects.createRainbowSparkles(gameState, scoreX, scoreY, 30)
+        return false -- Don't complete yet, wait for celebration
+    elseif (ballsFinished or (goalReached and gameState.victoryTimer <= 0)) and not roundSummary.active then
         local rows, total = calculateRoundScoreAndBonuses()
         showRoundSummaryPopup(rows, total)
         return true
@@ -245,6 +254,22 @@ function love.update(dt)
         end
     end
     
+    -- Update victory timer
+    if gameState.victoryTimer > 0 then
+        gameState.victoryTimer = gameState.victoryTimer - dt
+        
+        -- Create additional sparkles during celebration
+        if math.random() < 0.3 then -- 30% chance per frame
+            local scoreX = config.PLAY_X + config.PLAY_WIDTH/2 + math.random(-100, 100)
+            local scoreY = config.PLAY_Y + config.PLAY_HEIGHT/2 + math.random(-100, 100)
+            visualEffects.createRainbowSparkles(gameState, scoreX, scoreY, 8)
+        end
+        
+        if gameState.victoryTimer <= 0 then
+            gameState.victoryTimer = 0
+        end
+    end
+    
     -- Check for score increase and trigger effects
     if gameState.currentRound.score > (gameState.lastRoundScore or 0) then
         gameState.scoreGlowTimer = config.SCORE_GLOW_DURATION
@@ -257,7 +282,7 @@ function love.update(dt)
     end
     
     -- Check if round is complete during gameplay
-    if gameState.state == config.GAME_STATE.PLAYING and gameState.currentRound.score >= gameState.goal then
+    if gameState.state == config.GAME_STATE.PLAYING and gameState.currentRound.score >= gameState.goal and gameState.currentRound.active_balls == 0 then
         gameState.canAdvanceRound = true
     end
 

--- a/Peggame-cursor-debug-game-code-for-issues-cfbb/main.lua
+++ b/Peggame-cursor-debug-game-code-for-issues-cfbb/main.lua
@@ -228,9 +228,18 @@ function love.update(dt)
         end
     end
     
+    -- Update score scale timer
+    if gameState.scoreScaleTimer > 0 then
+        gameState.scoreScaleTimer = gameState.scoreScaleTimer - dt
+        if gameState.scoreScaleTimer < 0 then
+            gameState.scoreScaleTimer = 0
+        end
+    end
+    
     -- Check for score increase and trigger effects
     if gameState.currentRound.score > (gameState.lastRoundScore or 0) then
         gameState.scoreGlowTimer = config.SCORE_GLOW_DURATION
+        gameState.scoreScaleTimer = 0.5  -- Scale animation duration
         -- Add rainbow sparkles around score text
         local scoreX = config.PLAY_X + config.PLAY_WIDTH/2
         local scoreY = config.PLAY_Y + config.PLAY_HEIGHT + 100

--- a/Peggame-cursor-debug-game-code-for-issues-cfbb/power_ups.lua
+++ b/Peggame-cursor-debug-game-code-for-issues-cfbb/power_ups.lua
@@ -98,18 +98,19 @@ function powerUps.drawComboIndicator(gameState)
     if gameState.combo.count > 0 then
         local comboAlpha = 0.7 + 0.3 * math.sin(gameState.time * 10)
         love.graphics.setColor(1, 0.5, 0, comboAlpha)
-        -- Draw big combo multiplier under the combo meter
+        -- Position combo meter to the left of play area
         local meterWidth = 60
         local meterHeight = 400
-        local meterX = config.PLAY_X + config.PLAY_WIDTH + 20
+        local meterX = config.PLAY_X - meterWidth - 30  -- Moved to left side
         local meterY = config.PLAY_Y + config.PLAY_HEIGHT/2 - meterHeight/2
-        local textX = meterX + meterWidth + 20
-        local textY = meterY + meterHeight + 30
+        -- Place text close to the left of the meter
+        local textX = meterX - 120
+        local textY = meterY + meterHeight/2 - 10
         love.graphics.setFont(gameState.fonts.normal)
-        love.graphics.printf("COMBO x" .. string.format("%.1f", gameState.combo.multiplier), textX, textY, 200, "left")
-        -- Space out hit count text lower in the center
+        love.graphics.printf("COMBO x" .. string.format("%.1f", gameState.combo.multiplier), textX, textY, 110, "center")
+        -- Place hit count text close above the multiplier text
         love.graphics.setFont(gameState.fonts.normal)
-        love.graphics.printf(gameState.combo.count .. " hits!", 0, config.HEIGHT/2 + 40, config.WIDTH, "center")
+        love.graphics.printf(gameState.combo.count .. " hits!", textX, textY - 30, 110, "center")
     end
 end
 

--- a/Peggame-cursor-debug-game-code-for-issues-cfbb/shop_system.lua
+++ b/Peggame-cursor-debug-game-code-for-issues-cfbb/shop_system.lua
@@ -16,7 +16,8 @@ shopSystem.POPPERS = {
     {id = "comboPopper", name = "Combo Popper", desc = "Gain +20 points for every combo hit (3+ pegs in a single bounce).", price = 20, rarity = 0.8},
     {id = "explosivePopper", name = "Explosive Popper", desc = "Every 5th peg hit in a round explodes, clearing nearby pegs and granting +50 points (red explosion).", price = 30, rarity = 0.6},
     {id = "multiplierPopper", name = "Multiplier Popper", desc = "All points earned this round are multiplied by 1.2x.", price = 35, rarity = 0.5},
-    {id = "cincoPopper", name = "Cinco Popper", desc = "Gain +250 points every 5th bounce of the ball.", price = 45, rarity = 0.4}
+    {id = "cincoPopper", name = "Cinco Popper", desc = "Gain +250 points every 5th bounce of the ball.", price = 45, rarity = 0.4},
+    {id = "bananaPopper", name = "Banana Popper", desc = "Gain +250 points for every yellow peg hit this round.", price = 50, rarity = 0.3}
 }
 
 -- Define the Candies
@@ -123,6 +124,10 @@ function shopSystem.purchaseItem(gameState, item)
             return true
         elseif item.id == "cincoPopper" then
             gameState.poppers.cincoPopper = 1
+            gameState.coins = gameState.coins - item.price
+            return true
+        elseif item.id == "bananaPopper" then
+            gameState.poppers.bananaPopper = 1
             gameState.coins = gameState.coins - item.price
             return true
         elseif item.id == "speedBoost" then

--- a/Peggame-cursor-debug-game-code-for-issues-cfbb/shop_system.lua
+++ b/Peggame-cursor-debug-game-code-for-issues-cfbb/shop_system.lua
@@ -15,7 +15,8 @@ shopSystem.POPPERS = {
     {id = "wallPopper", name = "Wall Popper", desc = "Gain +15 points every time the ball bounces off a wall.", price = 16, rarity = 1},
     {id = "comboPopper", name = "Combo Popper", desc = "Gain +20 points for every combo hit (3+ pegs in a single bounce).", price = 20, rarity = 0.8},
     {id = "explosivePopper", name = "Explosive Popper", desc = "Every 5th peg hit in a round explodes, clearing nearby pegs and granting +50 points (red explosion).", price = 30, rarity = 0.6},
-    {id = "multiplierPopper", name = "Multiplier Popper", desc = "All points earned this round are multiplied by 1.2x.", price = 35, rarity = 0.5}
+    {id = "multiplierPopper", name = "Multiplier Popper", desc = "All points earned this round are multiplied by 1.2x.", price = 35, rarity = 0.5},
+    {id = "cincoPopper", name = "Cinco Popper", desc = "Gain +250 points every 5th bounce of the ball.", price = 45, rarity = 0.4}
 }
 
 -- Define the Candies
@@ -31,8 +32,7 @@ function shopSystem.isAvailable(gameState, id)
     if id == "extraBall4" then return gameState.round >= 20 and gameState.upgrades.extraBall3 and not gameState.upgrades.extraBall4 end
     if id == "multiplierBoost" then return gameState.multiplierBoostLevel < 5 end
     if id == "wallPoints" then return not gameState.upgrades.wallPoints end
-    if id == "wallToWall" then return gameState.wallToWallLevel < 5 end
-    if id == "paprika" then return gameState.paprikaLevel < 5 end
+
     if id == "extraLife" then return not gameState.upgrades.extraLife end
     if id == "speedBoost" then return true end -- Always available
     if id == "giantBall" then return true end -- Always available
@@ -80,21 +80,7 @@ function shopSystem.rerollShopItems(gameState)
     end
 end
 
--- Reroll shop perks
-function shopSystem.rerollShopPerks(gameState)
-    gameState.shopPerks = {}
-    local available = {}
-    for _, perk in ipairs(gameState.allPerks) do
-        if shopSystem.isAvailable(gameState, perk.id) then
-            table.insert(available, perk)
-        end
-    end
-    for i = 1, math.min(6, #available) do
-        local idx = math.random(#available)
-        table.insert(gameState.shopPerks, available[idx])
-        table.remove(available, idx)
-    end
-end
+
 
 -- Purchase item
 function shopSystem.purchaseItem(gameState, item)
@@ -135,6 +121,10 @@ function shopSystem.purchaseItem(gameState, item)
             gameState.poppers.multiplierPopper = 1
             gameState.coins = gameState.coins - item.price
             return true
+        elseif item.id == "cincoPopper" then
+            gameState.poppers.cincoPopper = 1
+            gameState.coins = gameState.coins - item.price
+            return true
         elseif item.id == "speedBoost" then
             require('power_ups').activatePowerUp(gameState, "speedBoost")
             gameState.coins = gameState.coins - item.price
@@ -159,52 +149,7 @@ function shopSystem.purchaseItem(gameState, item)
         elseif item.id == "wallPoints" then
             gameState.upgrades.wallPoints = true
             gameState.coins = gameState.coins - item.price
-        elseif item.id == "wallToWall" then
-            if gameState.wallToWallLevel < 5 then
-                gameState.wallToWallLevel = gameState.wallToWallLevel + 1
-                -- Find existing wall to wall perk or add new one
-                local found = false
-                for j = 1, 5 do
-                    if gameState.perks[j] == 1 then
-                        gameState.perkCounts[j] = gameState.perkCounts[j] + 1
-                        found = true
-                        break
-                    end
-                end
-                if not found then
-                    for j = 1, 5 do
-                        if gameState.perks[j] == 0 then
-                            gameState.perks[j] = 1
-                            gameState.perkCounts[j] = 1
-                            break
-                        end
-                    end
-                end
-                gameState.coins = gameState.coins - item.price
-            end
-        elseif item.id == "paprika" then
-            if gameState.paprikaLevel < 5 then
-                gameState.paprikaLevel = gameState.paprikaLevel + 1
-                -- Find existing paprika perk or add new one
-                local found = false
-                for j = 1, 5 do
-                    if gameState.perks[j] == 2 then
-                        gameState.perkCounts[j] = gameState.perkCounts[j] + 1
-                        found = true
-                        break
-                    end
-                end
-                if not found then
-                    for j = 1, 5 do
-                        if gameState.perks[j] == 0 then
-                            gameState.perks[j] = 2
-                            gameState.perkCounts[j] = 1
-                            break
-                        end
-                    end
-                end
-                gameState.coins = gameState.coins - item.price
-            end
+
         elseif item.id == "comboKing" then
             gameState.upgrades.comboKing = true
             gameState.coins = gameState.coins - item.price

--- a/Peggame-cursor-debug-game-code-for-issues-cfbb/shop_system.lua
+++ b/Peggame-cursor-debug-game-code-for-issues-cfbb/shop_system.lua
@@ -14,7 +14,7 @@ shopSystem.POPPERS = {
     {id = "bouncePopper", name = "Bounce Popper", desc = "Gain +10 points every time the ball bounces.", price = 22, rarity = 0.8},
     {id = "wallPopper", name = "Wall Popper", desc = "Gain +15 points every time the ball bounces off a wall.", price = 16, rarity = 1},
     {id = "comboPopper", name = "Combo Popper", desc = "Gain +20 points for every combo hit (3+ pegs in a single bounce).", price = 20, rarity = 0.8},
-    {id = "explosivePopper", name = "Explosive Popper", desc = "Every 5th peg hit in a round explodes, clearing nearby pegs and granting +50 points (red explosion).", price = 30, rarity = 0.6},
+    {id = "explosivePopper", name = "Explosive Popper", desc = "Every 10th peg hit in a round explodes, clearing nearby pegs and granting +50 points (red explosion).", price = 30, rarity = 0.6},
     {id = "multiplierPopper", name = "Multiplier Popper", desc = "All points earned this round are multiplied by 1.2x.", price = 35, rarity = 0.5},
     {id = "cincoPopper", name = "Cinco Popper", desc = "Gain +250 points every 5th bounce of the ball.", price = 45, rarity = 0.4},
     {id = "bananaPopper", name = "Banana Popper", desc = "Gain +250 points for every yellow peg hit this round.", price = 50, rarity = 0.3}

--- a/Peggame-cursor-debug-game-code-for-issues-cfbb/ui_system.lua
+++ b/Peggame-cursor-debug-game-code-for-issues-cfbb/ui_system.lua
@@ -314,19 +314,21 @@ function uiSystem.drawShop(gameState)
         local canAfford = gameState.coins >= candy.price and not (gameState.candyBought and gameState.candyBought[candy.id])
         local bought = gameState.candyBought and gameState.candyBought[candy.id]
         local iconX = config.WIDTH/2 - iconSize/2
-        -- Draw heart icon for Candy of Life
+        -- Draw heart icon for Candy of Life with floating animation
+        local float = math.sin(gameState.time * 2 + iconX) * 6
+        local heartY = y + float
         love.graphics.setColor(1, 0.3, 0.5, bought and 0.3 or 1)
         love.graphics.polygon("fill",
-            iconX + 40, y + 40,
-            iconX + 20, y + 30,
-            iconX + 10, y + 50,
-            iconX + 40, y + 80,
-            iconX + 70, y + 50,
-            iconX + 60, y + 30
+            iconX + 40, heartY + 40,
+            iconX + 20, heartY + 30,
+            iconX + 10, heartY + 50,
+            iconX + 40, heartY + 80,
+            iconX + 70, heartY + 50,
+            iconX + 60, heartY + 30
         )
         love.graphics.setColor(1, 0.6, 0.8, bought and 0.3 or 1)
-        love.graphics.circle("fill", iconX + 25, y + 38, 16)
-        love.graphics.circle("fill", iconX + 55, y + 38, 16)
+        love.graphics.circle("fill", iconX + 25, heartY + 38, 16)
+        love.graphics.circle("fill", iconX + 55, heartY + 38, 16)
         -- Draw buy button to the right of icon (centered)
         local buyX, buyY, buyW, buyH = config.WIDTH/2 + iconSize/2 + 16, y + 20, 80, 40
         love.graphics.setColor(canAfford and not bought and {0.9, 0.8, 0.2, 1} or {0.5, 0.5, 0.2, 0.7})
@@ -620,6 +622,35 @@ function uiSystem.drawMultiplierMeter(gameState)
     love.graphics.printf(gameState.multiplierMeter .. "/10", meterX - 20, meterY + meterHeight + 10, meterWidth + 40, "center")
 end
 
+-- Draw popper activations
+function uiSystem.drawPopperActivations(gameState)
+    if not gameState.popperActivations or #gameState.popperActivations == 0 then
+        return
+    end
+    
+    local startX = config.PLAY_X + 10
+    local startY = config.PLAY_Y + 10
+    local spacing = 30
+    
+    for i, activation in ipairs(gameState.popperActivations) do
+        local y = startY + (i - 1) * spacing
+        local alpha = math.min(activation.timer / 2.0, 1.0)
+        
+        -- Draw popper icon
+        love.graphics.push()
+        love.graphics.translate(startX, y)
+        drawPopperIcon(activation.type .. "Popper", 0, 0, gameState.time, 0.5)
+        love.graphics.pop()
+        
+        -- Draw points text to the right of icon
+        love.graphics.setColor(activation.color[1], activation.color[2], activation.color[3], alpha)
+        love.graphics.setFont(gameState.fonts.normal)
+        love.graphics.printf("+" .. activation.points, startX + 50, y + 15, 100, "left")
+    end
+    
+    love.graphics.setColor(1, 1, 1, 1) -- Reset color
+end
+
 -- Draw candy row
 function uiSystem.drawCandyRow(gameState)
     local shopSystem = require('shop_system')
@@ -708,9 +739,8 @@ function uiSystem.drawPoppers(gameState)
         local angle = (i / 8) * math.pi * 2
         local ox = math.cos(angle) * 3
         local oy = math.sin(angle) * 3
-        local hue = ((gameState.time * 100 + i * 45) % 360) / 360
-        local r, g, b = config.COLORS.rainbow(hue)
-        love.graphics.setColor(r, g, b, 0.8)
+        local glow = 0.5 + 0.3 * math.sin(gameState.time * 4)
+        love.graphics.setColor(0.2, 1, 0.2, glow) -- Green glowing outline
         love.graphics.printf(label, x + ox - 10, y + oy - 60, 200, "left")
     end
     love.graphics.setColor(1, 1, 1)
@@ -761,9 +791,8 @@ function uiSystem.drawCandies(gameState)
         local angle = (i / 8) * math.pi * 2
         local ox = math.cos(angle) * 3
         local oy = math.sin(angle) * 3
-        local hue = ((gameState.time * 100 + i * 45) % 360) / 360
-        local r, g, b = config.COLORS.rainbow(hue)
-        love.graphics.setColor(r, g, b, 0.8)
+        local glow = 0.5 + 0.3 * math.sin(gameState.time * 4)
+        love.graphics.setColor(1, 0.4, 0.8, glow) -- Pink glowing outline
         love.graphics.printf(label, x + ox - 10, y + oy - 60, 200, "left")
     end
     love.graphics.setColor(1, 1, 1)

--- a/Peggame-cursor-debug-game-code-for-issues-cfbb/ui_system.lua
+++ b/Peggame-cursor-debug-game-code-for-issues-cfbb/ui_system.lua
@@ -71,6 +71,23 @@ local function drawPopperIcon(popperId, x, y, time, scale)
             love.graphics.rectangle("fill", -4*scale, -32*scale, 8*scale, 64*scale, 4*scale, 4*scale)
             love.graphics.pop()
         end
+    elseif popperId == "cincoPopper" then
+        -- Draw a hand with 5 fingers
+        love.graphics.setColor(1, 0.8, 0.6) -- Skin tone
+        -- Palm
+        love.graphics.ellipse("fill", x + 40*scale, y + 50*scale, 20*scale, 25*scale)
+        -- Thumb
+        love.graphics.ellipse("fill", x + 22*scale, y + 45*scale, 8*scale, 15*scale)
+        -- Fingers
+        local fingerOffsets = {-12, -4, 4, 12}
+        for i, offset in ipairs(fingerOffsets) do
+            love.graphics.rectangle("fill", x + 38*scale + offset*scale, y + 25*scale, 4*scale, 20*scale, 2*scale, 2*scale)
+        end
+        -- Number "5" in the palm
+        love.graphics.setColor(1, 0.2, 0.2)
+        love.graphics.setFont(love.graphics.newFont(14*scale))
+        love.graphics.printf("5", x + 32*scale, y + 44*scale, 16*scale, "center")
+        love.graphics.setFont(love.graphics.getFont()) -- Reset font
     end
 end
 
@@ -522,7 +539,7 @@ end
 function uiSystem.drawMultiplierMeter(gameState)
     local meterWidth = 60
     local meterHeight = 400
-    local meterX = config.PLAY_X + config.PLAY_WIDTH + 20
+    local meterX = config.PLAY_X - meterWidth - 30  -- Moved to left side to match combo indicator
     local meterY = config.PLAY_Y + config.PLAY_HEIGHT/2 - meterHeight/2
     
     -- Background

--- a/Peggame-cursor-debug-game-code-for-issues-cfbb/ui_system.lua
+++ b/Peggame-cursor-debug-game-code-for-issues-cfbb/ui_system.lua
@@ -24,6 +24,21 @@ local function drawPopperIcon(popperId, x, y, time, scale)
         love.graphics.ellipse("fill", x + 40*scale, y + 40*scale, 32*scale, 18*scale)
         love.graphics.setColor(0.5, 0, 0)
         love.graphics.arc("fill", x + 40*scale, y + 22*scale, 14*scale, math.pi, math.pi * 2)
+    elseif popperId == "bluePopper" then
+        -- Draw a blue UFO
+        love.graphics.setColor(0.2, 0.4, 1) -- Blue main body
+        love.graphics.ellipse("fill", x + 40*scale, y + 45*scale, 30*scale, 15*scale) -- Main saucer
+        love.graphics.setColor(0.4, 0.6, 1) -- Lighter blue dome
+        love.graphics.ellipse("fill", x + 40*scale, y + 35*scale, 20*scale, 12*scale) -- Dome
+        -- UFO lights (animated)
+        for i = 1, 6 do
+            local angle = (i / 6) * math.pi * 2 + time * 3
+            local lightX = x + 40*scale + math.cos(angle) * 22*scale
+            local lightY = y + 45*scale + math.sin(angle) * 8*scale
+            local brightness = 0.5 + 0.5 * math.sin(time * 8 + i)
+            love.graphics.setColor(1, 1, 1, brightness)
+            love.graphics.circle("fill", lightX, lightY, 2*scale)
+        end
     elseif popperId == "wallPopper" then
         love.graphics.setColor(0.7, 0.7, 0.7)
         love.graphics.rectangle("fill", x + 20*scale, y + 32*scale, 40*scale, 28*scale, 8*scale, 8*scale)
@@ -88,6 +103,25 @@ local function drawPopperIcon(popperId, x, y, time, scale)
         love.graphics.setFont(love.graphics.newFont(14*scale))
         love.graphics.printf("5", x + 32*scale, y + 44*scale, 16*scale, "center")
         love.graphics.setFont(love.graphics.getFont()) -- Reset font
+    elseif popperId == "bananaPopper" then
+        -- Draw a banana
+        love.graphics.setColor(1, 1, 0) -- Yellow banana
+        -- Banana body (curved)
+        love.graphics.push()
+        love.graphics.translate(x + 40*scale, y + 40*scale)
+        love.graphics.rotate(math.pi / 6) -- Slight curve
+        love.graphics.ellipse("fill", 0, 0, 25*scale, 12*scale)
+        love.graphics.pop()
+        -- Banana stem (brown)
+        love.graphics.setColor(0.4, 0.3, 0.1)
+        love.graphics.circle("fill", x + 28*scale, y + 25*scale, 4*scale)
+        -- Banana highlights
+        love.graphics.setColor(1, 1, 0.7)
+        love.graphics.push()
+        love.graphics.translate(x + 40*scale, y + 40*scale)
+        love.graphics.rotate(math.pi / 6)
+        love.graphics.ellipse("fill", -5*scale, -2*scale, 8*scale, 3*scale)
+        love.graphics.pop()
     end
 end
 

--- a/Peggame-cursor-debug-game-code-for-issues-cfbb/ui_system.lua
+++ b/Peggame-cursor-debug-game-code-for-issues-cfbb/ui_system.lua
@@ -15,15 +15,35 @@ local function drawPopperIcon(popperId, x, y, time, scale)
     local float = math.sin(time * 2 + x) * 6
     y = y + float
     if popperId == "greenPopper" then
-        love.graphics.setColor(0.1, 0.8, 0.2)
-        love.graphics.ellipse("fill", x + 40*scale, y + 40*scale, 32*scale, 18*scale)
-        love.graphics.setColor(0, 0.5, 0)
-        love.graphics.arc("fill", x + 40*scale, y + 22*scale, 14*scale, math.pi, math.pi * 2)
+        -- Draw a green UFO
+        love.graphics.setColor(0.2, 0.8, 0.2) -- Green main body
+        love.graphics.ellipse("fill", x + 40*scale, y + 45*scale, 30*scale, 15*scale) -- Main saucer
+        love.graphics.setColor(0.4, 1, 0.4) -- Lighter green dome
+        love.graphics.ellipse("fill", x + 40*scale, y + 35*scale, 20*scale, 12*scale) -- Dome
+        -- UFO lights (animated)
+        for i = 1, 6 do
+            local angle = (i / 6) * math.pi * 2 + time * 3
+            local lightX = x + 40*scale + math.cos(angle) * 22*scale
+            local lightY = y + 45*scale + math.sin(angle) * 8*scale
+            local brightness = 0.5 + 0.5 * math.sin(time * 8 + i)
+            love.graphics.setColor(1, 1, 1, brightness)
+            love.graphics.circle("fill", lightX, lightY, 2*scale)
+        end
     elseif popperId == "redPopper" then
-        love.graphics.setColor(0.9, 0.1, 0.1)
-        love.graphics.ellipse("fill", x + 40*scale, y + 40*scale, 32*scale, 18*scale)
-        love.graphics.setColor(0.5, 0, 0)
-        love.graphics.arc("fill", x + 40*scale, y + 22*scale, 14*scale, math.pi, math.pi * 2)
+        -- Draw a red UFO
+        love.graphics.setColor(0.8, 0.2, 0.2) -- Red main body
+        love.graphics.ellipse("fill", x + 40*scale, y + 45*scale, 30*scale, 15*scale) -- Main saucer
+        love.graphics.setColor(1, 0.4, 0.4) -- Lighter red dome
+        love.graphics.ellipse("fill", x + 40*scale, y + 35*scale, 20*scale, 12*scale) -- Dome
+        -- UFO lights (animated)
+        for i = 1, 6 do
+            local angle = (i / 6) * math.pi * 2 + time * 3
+            local lightX = x + 40*scale + math.cos(angle) * 22*scale
+            local lightY = y + 45*scale + math.sin(angle) * 8*scale
+            local brightness = 0.5 + 0.5 * math.sin(time * 8 + i)
+            love.graphics.setColor(1, 1, 1, brightness)
+            love.graphics.circle("fill", lightX, lightY, 2*scale)
+        end
     elseif popperId == "bluePopper" then
         -- Draw a blue UFO
         love.graphics.setColor(0.2, 0.4, 1) -- Blue main body

--- a/Peggame-cursor-debug-game-code-for-issues-cfbb/ui_system.lua
+++ b/Peggame-cursor-debug-game-code-for-issues-cfbb/ui_system.lua
@@ -522,8 +522,20 @@ function uiSystem.drawUI(gameState)
         love.graphics.setColor(1, 1, 1)
     end
     
+    -- Calculate scale based on scoreScaleTimer
+    local scale = 1.0
+    if gameState.scoreScaleTimer > 0 then
+        -- Create a bouncy scale effect that starts big and shrinks back to normal
+        local progress = 1 - (gameState.scoreScaleTimer / 0.5) -- Normalize to 0-1
+        scale = 1.0 + 0.5 * math.sin(progress * math.pi) -- Smooth sine curve from 1.0 to 1.5 and back
+    end
+    
+    love.graphics.push()
+    love.graphics.translate(progressX + progressWidth/2, scoreY + 20) -- Center point for scaling
+    love.graphics.scale(scale, scale)
     love.graphics.setFont(gameState.fonts.title)
-    love.graphics.printf(scoreText, progressX, scoreY, progressWidth, "center")
+    love.graphics.printf(scoreText, -progressWidth/2, -20, progressWidth, "center")
+    love.graphics.pop()
 
     -- Show yellow text for ball collision points above meter for 1 second
     if gameState.lastBallCollisionPoints and love.timer.getTime() - gameState.lastBallCollisionTime < 1 then


### PR DESCRIPTION
Introduces new poppers and UI enhancements, resolves multiple gameplay bugs, and removes the perk system.

This PR addresses several user requests and critical bugs. Key changes include:
- Fixing shop buy buttons (incorrect variable usage in click detection).
- Adding 'Cinco' and 'Banana' poppers with custom icons and purchase logic.
- Completely removing the perk system from all relevant files.
- Repositioning the combo meter, its text, and associated particles to the left side of the play area.
- Resolving a nil peg crash during explosive popper activation and ensuring explosive poppers correctly add scores from all destroyed pegs.
- Implementing a scaling animation for the score display text, triggered only when the score increases.